### PR TITLE
Silence tcp i/o timeout errors

### DIFF
--- a/server/starter.go
+++ b/server/starter.go
@@ -82,7 +82,9 @@ func Start(fm *paradise.FileManager, am *paradise.AuthManager, gracefulChild boo
 		Listener.(*net.TCPListener).SetDeadline(time.Now().Add(60 * time.Second))
 		connection, err := Listener.Accept()
 		if err != nil {
-			fmt.Println("listening error ", err)
+			if opError, ok := err.(*net.OpError); !ok || !opError.Timeout() {
+				fmt.Println("listening error ", err)
+			}
 		} else {
 		  cid := genClientID()
 		  p := NewParadise(connection, cid, time.Now().Unix())


### PR DESCRIPTION
# L82 SetDeadline throws a Timeout error every 60 seconds that causes "listening error ..." to be printed out. This error is thrown by design and handled by the for loop. Could cause some confusion if not gated on #L85. Patch to echo only legitimate listening errors.
